### PR TITLE
update SaveAsync method use sync Add method

### DIFF
--- a/src/Skoruba.AuditLogging.EntityFramework/Repositories/AuditLoggingRepository.cs
+++ b/src/Skoruba.AuditLogging.EntityFramework/Repositories/AuditLoggingRepository.cs
@@ -55,7 +55,7 @@ namespace Skoruba.AuditLogging.EntityFramework.Repositories
 
         public virtual async Task SaveAsync(TAuditLog auditLog)
         {
-            await DbContext.AuditLog.AddAsync(auditLog);
+            DbContext.AuditLog.Add(auditLog);
             await DbContext.SaveChangesAsync();
         }
     }


### PR DESCRIPTION
from the comments from the `AddAsync` method, we should not use the `AddAsync` in common senses

> This method is async only to allow special value generators, such as the one used by 'Microsoft.EntityFrameworkCore.Metadata.SqlServerValueGenerationStrategy.SequenceHiLo', to access the database asynchronously. For all other cases the non async method should be used.

see details here <https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.addasync?view=efcore-3.1>